### PR TITLE
refactor: add jsx-a11y rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,12 @@
     "import/prefer-default-export": "off",
     "jsx-a11y/aria-role": 1,
     "jsx-a11y/href-no-hash": "off",
-    "jsx-a11y/label-has-for": 1,
+    "jsx-a11y/label-has-associated-control": [
+      2,
+      {
+        "assert": "either"
+      }
+    ],
     "jsx-a11y/no-autofocus": 1,
     "jsx-a11y/no-noninteractive-element-interactions": 1,
     "jsx-a11y/anchor-is-valid": 1,


### PR DESCRIPTION
J'ai supprimé une regle deprecated pour ajouter la nouvelle

De plus dans la nouvelle on autorise de mettre un input loin du label, tant qu'il y a labelFor de renseigné